### PR TITLE
Fix crash on servers

### DIFF
--- a/src/main/java/shadows/endertweaker/AlloySmelter.java
+++ b/src/main/java/shadows/endertweaker/AlloySmelter.java
@@ -24,7 +24,7 @@ public class AlloySmelter {
 		if (hasErrors(output, input)) return;
 		EnderTweaker.ADDITIONS.add(() -> {
 			RecipeOutput out = new RecipeOutput(CraftTweakerMC.getItemStack(output), 1, xp);
-			ManyToOneRecipe rec = new ManyToOneRecipe(out, energyCost, RecipeBonusType.NONE, EnderTweaker.toEIOInputs(input));
+			ManyToOneRecipe rec = new ManyToOneRecipe(out, energyCost, RecipeBonusType.NONE, RecipeUtils.toEIOInputs(input));
 			AlloyRecipeManager.getInstance().addRecipe(rec);
 		});
 	}
@@ -56,7 +56,7 @@ public class AlloySmelter {
 			return true;
 		}
 		if (input.length > 3) {
-			CraftTweakerAPI.logError("Invalid Alloy Smelter input, must be between 1 and 3 inputs.  Provided: " + EnderTweaker.getDisplayString(input));
+			CraftTweakerAPI.logError("Invalid Alloy Smelter input, must be between 1 and 3 inputs.  Provided: " + RecipeUtils.getDisplayString(input));
 			return true;
 		}
 		return false;

--- a/src/main/java/shadows/endertweaker/EnderTweaker.java
+++ b/src/main/java/shadows/endertweaker/EnderTweaker.java
@@ -3,17 +3,10 @@ package shadows.endertweaker;
 import java.util.ArrayList;
 import java.util.List;
 
-import crafttweaker.api.item.IIngredient;
-import crafttweaker.api.item.IItemStack;
-import crafttweaker.api.item.WeightedItemStack;
-import crafttweaker.api.minecraft.CraftTweakerMC;
-import crazypants.enderio.base.recipe.IRecipeInput;
-import crazypants.enderio.base.recipe.RecipeOutput;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLLoadCompleteEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
-import shadows.endertweaker.recipe.RecipeInput;
 
 @Mod(modid = EnderTweaker.MODID, name = EnderTweaker.MODNAME, version = EnderTweaker.VERSION, dependencies = "required:enderio;required-after:crafttweaker;before:jei")
 public class EnderTweaker {
@@ -37,49 +30,4 @@ public class EnderTweaker {
 			r.run();
 		ADDITIONS.clear();
 	}
-
-	public static IRecipeInput[] toEIOInputs(IIngredient[] inputs) {
-		IRecipeInput[] ret = new IRecipeInput[inputs.length];
-		for (int i = 0; i < ret.length; i++) {
-			ret[i] = toInput(inputs[i]);
-		}
-		return ret;
-	}
-
-	public static RecipeOutput[] toEIOOutputs(IItemStack[] inputs, float[] chances, float[] xp) {
-		RecipeOutput[] ret = new RecipeOutput[inputs.length];
-		for (int i = 0; i < ret.length; i++) {
-			ret[i] = new RecipeOutput(CraftTweakerMC.getItemStack(inputs[i]), chances[i], xp[i]);
-		}
-		return ret;
-	}
-	
-	public static RecipeOutput[] toEIOOutputs(WeightedItemStack[] inputs, float[] xp) {
-		RecipeOutput[] ret = new RecipeOutput[inputs.length];
-		for (int i = 0; i < ret.length; i++) {
-			ret[i] = new RecipeOutput(CraftTweakerMC.getItemStack(inputs[i].getStack()), inputs[i].getChance(), xp[i]);
-		}
-		return ret;
-	}
-
-	public static RecipeInput toInput(IIngredient ing) {
-		return new RecipeInput(CraftTweakerMC.getIngredient(ing));
-	}
-
-	public static String getDisplayString(IIngredient... ings) {
-		StringBuilder sb = new StringBuilder("[");
-		for (IIngredient i : ings)
-			sb.append(i == null ? i : i.toCommandString() + ",");
-		sb.replace(sb.length() - 1, sb.length(), "");
-		return sb.append("]").toString();
-	}
-	
-	public static String getDisplayString(WeightedItemStack... ings) {
-		StringBuilder sb = new StringBuilder("[");
-		for (WeightedItemStack i : ings)
-			sb.append(i == null ? i : i.getStack().toCommandString() + " % " + i.getPercent() + ",");
-		sb.replace(sb.length() - 1, sb.length(), "");
-		return sb.append("]").toString();
-	}
-
 }

--- a/src/main/java/shadows/endertweaker/RecipeUtils.java
+++ b/src/main/java/shadows/endertweaker/RecipeUtils.java
@@ -1,0 +1,55 @@
+package shadows.endertweaker;
+
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.item.WeightedItemStack;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import crazypants.enderio.base.recipe.IRecipeInput;
+import crazypants.enderio.base.recipe.RecipeOutput;
+import shadows.endertweaker.recipe.RecipeInput;
+
+public class RecipeUtils {
+    public static IRecipeInput[] toEIOInputs(IIngredient[] inputs) {
+        IRecipeInput[] ret = new IRecipeInput[inputs.length];
+        for (int i = 0; i < ret.length; i++) {
+            ret[i] = toInput(inputs[i]);
+        }
+        return ret;
+    }
+
+    public static RecipeOutput[] toEIOOutputs(IItemStack[] inputs, float[] chances, float[] xp) {
+        RecipeOutput[] ret = new RecipeOutput[inputs.length];
+        for (int i = 0; i < ret.length; i++) {
+            ret[i] = new RecipeOutput(CraftTweakerMC.getItemStack(inputs[i]), chances[i], xp[i]);
+        }
+        return ret;
+    }
+
+    public static RecipeOutput[] toEIOOutputs(WeightedItemStack[] inputs, float[] xp) {
+        RecipeOutput[] ret = new RecipeOutput[inputs.length];
+        for (int i = 0; i < ret.length; i++) {
+            ret[i] = new RecipeOutput(CraftTweakerMC.getItemStack(inputs[i].getStack()), inputs[i].getChance(), xp[i]);
+        }
+        return ret;
+    }
+
+    public static RecipeInput toInput(IIngredient ing) {
+        return new RecipeInput(CraftTweakerMC.getIngredient(ing));
+    }
+
+    public static String getDisplayString(IIngredient... ings) {
+        StringBuilder sb = new StringBuilder("[");
+        for (IIngredient i : ings)
+            sb.append(i == null ? i : i.toCommandString() + ",");
+        sb.replace(sb.length() - 1, sb.length(), "");
+        return sb.append("]").toString();
+    }
+
+    public static String getDisplayString(WeightedItemStack... ings) {
+        StringBuilder sb = new StringBuilder("[");
+        for (WeightedItemStack i : ings)
+            sb.append(i == null ? i : i.getStack().toCommandString() + " % " + i.getPercent() + ",");
+        sb.replace(sb.length() - 1, sb.length(), "");
+        return sb.append("]").toString();
+    }
+}

--- a/src/main/java/shadows/endertweaker/SagMill.java
+++ b/src/main/java/shadows/endertweaker/SagMill.java
@@ -34,7 +34,7 @@ public class SagMill {
 		final float[] xpa = xp;
 		if (hasErrors(output, chances, input, xpa, bonusType)) return;
 		EnderTweaker.ADDITIONS.add(() -> {
-			SagRecipe recipe = new SagRecipe(new RecipeInput(CraftTweakerMC.getIngredient(input)), energyCost <= 0 ? 5000 : energyCost, RecipeBonusType.valueOf(Strings.isNullOrEmpty(bonusType) ? "NONE" : bonusType), EnderTweaker.toEIOOutputs(output, chances, xpa));
+			SagRecipe recipe = new SagRecipe(new RecipeInput(CraftTweakerMC.getIngredient(input)), energyCost <= 0 ? 5000 : energyCost, RecipeBonusType.valueOf(Strings.isNullOrEmpty(bonusType) ? "NONE" : bonusType), RecipeUtils.toEIOOutputs(output, chances, xpa));
 			SagMillRecipeManager.getInstance().addRecipe(recipe);
 		});
 	}
@@ -48,7 +48,7 @@ public class SagMill {
 		final float[] xpa = xp;
 		if (hasErrors(output, input, xpa, bonusType)) return;
 		EnderTweaker.ADDITIONS.add(() -> {
-			SagRecipe recipe = new SagRecipe(new RecipeInput(CraftTweakerMC.getIngredient(input)), energyCost <= 0 ? 5000 : energyCost, RecipeBonusType.valueOf(Strings.isNullOrEmpty(bonusType) ? "NONE" : bonusType), EnderTweaker.toEIOOutputs(output, xpa));
+			SagRecipe recipe = new SagRecipe(new RecipeInput(CraftTweakerMC.getIngredient(input)), energyCost <= 0 ? 5000 : energyCost, RecipeBonusType.valueOf(Strings.isNullOrEmpty(bonusType) ? "NONE" : bonusType), RecipeUtils.toEIOOutputs(output, xpa));
 			SagMillRecipeManager.getInstance().addRecipe(recipe);
 		});
 	}
@@ -74,15 +74,15 @@ public class SagMill {
 			return true;
 		}
 		if (output.length > 4) {
-			CraftTweakerAPI.logError("Invalid output (more than four entries) in Sag Mill recipe: " + EnderTweaker.getDisplayString(output));
+			CraftTweakerAPI.logError("Invalid output (more than four entries) in Sag Mill recipe: " + RecipeUtils.getDisplayString(output));
 			return true;
 		}
 		if (output.length != chances.length) {
-			CraftTweakerAPI.logError("Invalid output chances (chances do not match outputs) in Sag Mill recipe: " + EnderTweaker.getDisplayString(output) + " | " + chances);
+			CraftTweakerAPI.logError("Invalid output chances (chances do not match outputs) in Sag Mill recipe: " + RecipeUtils.getDisplayString(output) + " | " + chances);
 			return true;
 		}
 		if (output.length != xp.length) {
-			CraftTweakerAPI.logError("Invalid output xp (xp does not match outputs) in Sag Mill recipe: " + EnderTweaker.getDisplayString(output) + " | " + xp);
+			CraftTweakerAPI.logError("Invalid output xp (xp does not match outputs) in Sag Mill recipe: " + RecipeUtils.getDisplayString(output) + " | " + xp);
 			return true;
 		}
 		if (input == null) {
@@ -102,11 +102,11 @@ public class SagMill {
 			return true;
 		}
 		if (output.length > 4) {
-			CraftTweakerAPI.logError("Invalid output (more than four entries) in Sag Mill recipe: " + EnderTweaker.getDisplayString(output));
+			CraftTweakerAPI.logError("Invalid output (more than four entries) in Sag Mill recipe: " + RecipeUtils.getDisplayString(output));
 			return true;
 		}
 		if (output.length != xp.length) {
-			CraftTweakerAPI.logError("Invalid output xp (xp does not match outputs) in Sag Mill recipe: " + EnderTweaker.getDisplayString(output) + " | " + xp);
+			CraftTweakerAPI.logError("Invalid output xp (xp does not match outputs) in Sag Mill recipe: " + RecipeUtils.getDisplayString(output) + " | " + xp);
 			return true;
 		}
 		if (input == null) {

--- a/src/main/java/shadows/endertweaker/SliceNSplice.java
+++ b/src/main/java/shadows/endertweaker/SliceNSplice.java
@@ -24,7 +24,7 @@ public class SliceNSplice {
 		if (hasErrors(output, input)) return;
 		EnderTweaker.ADDITIONS.add(() -> {
 			RecipeOutput out = new RecipeOutput(CraftTweakerMC.getItemStack(output), 1, xp);
-			ManyToOneRecipe rec = new ManyToOneRecipe(out, energyCost <= 0 ? 5000 : energyCost, RecipeBonusType.NONE, EnderTweaker.toEIOInputs(input));
+			ManyToOneRecipe rec = new ManyToOneRecipe(out, energyCost <= 0 ? 5000 : energyCost, RecipeBonusType.NONE, RecipeUtils.toEIOInputs(input));
 			SliceAndSpliceRecipeManager.getInstance().addRecipe(rec);
 		});
 	}
@@ -56,7 +56,7 @@ public class SliceNSplice {
 			return true;
 		}
 		if (input.length > 6) {
-			CraftTweakerAPI.logError("Invalid Slice'n'Splice input, must be between 1 and 6 inputs.  Provided: " + EnderTweaker.getDisplayString(input));
+			CraftTweakerAPI.logError("Invalid Slice'n'Splice input, must be between 1 and 6 inputs.  Provided: " + RecipeUtils.getDisplayString(input));
 			return true;
 		}
 		return false;

--- a/src/main/java/shadows/endertweaker/Vat.java
+++ b/src/main/java/shadows/endertweaker/Vat.java
@@ -68,11 +68,11 @@ public class Vat {
 			return true;
 		}
 		if (slot1Solids.length != slot1Mults.length) {
-			CraftTweakerAPI.logError("Invalid slot 1 configuration in vat recipe; slot1Solids must have equal length of slot1Mults! Provided: " + EnderTweaker.getDisplayString(slot1Solids) + " | " + slot1Mults);
+			CraftTweakerAPI.logError("Invalid slot 1 configuration in vat recipe; slot1Solids must have equal length of slot1Mults! Provided: " + RecipeUtils.getDisplayString(slot1Solids) + " | " + slot1Mults);
 			return true;
 		}
 		if (slot2Solids.length != slot2Mults.length) {
-			CraftTweakerAPI.logError("Invalid slot 2 configuration in vat recipe; slot1Solids must have equal length of slot2Mults! Provided: " + EnderTweaker.getDisplayString(slot2Solids) + " | " + slot2Mults);
+			CraftTweakerAPI.logError("Invalid slot 2 configuration in vat recipe; slot1Solids must have equal length of slot2Mults! Provided: " + RecipeUtils.getDisplayString(slot2Solids) + " | " + slot2Mults);
 			return true;
 		}
 		return false;


### PR DESCRIPTION
Moved util methods to their own class, so that servers don't crash reading the method signatures if Ender Tweaker loads before Ender IO. Nothing in Ender IO is used until later, so we previously had moved that to just being a required dependency so that we can force it before JEI. The client is fine with it how it is now, but apparently it causes a crash on servers. This fixes that.