### PR TITLE
Fix Crash trying to remove recipe from machine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,6 @@ repositories {
         url "http://dvs1.progwml6.com/files/maven"
     }
 	maven {
-		url "http://maven.tehnut.info"
-	}
-	maven {
 		url "http://maven.tterrag.com"
 	}
 	maven {
@@ -43,8 +40,8 @@ repositories {
 
 dependencies {
 	deobfCompile "mezz.jei:jei_1.12.2:+"
-	deobfCompile "mcp.mobius.waila:Hwyla:1.8.+"
-	deobfCompile("com.enderio:EnderIO:1.12.2-5.3.68"){
+    deobfCompile "mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.4.28-17"
+	deobfCompile("com.enderio:EnderIO:1.12.2-5.3.70"){
         transitive = false
     }
 	deobfCompile "com.enderio.core:EnderCore:1.12.2-+"

--- a/src/main/java/shadows/endertweaker/Enchanter.java
+++ b/src/main/java/shadows/endertweaker/Enchanter.java
@@ -52,15 +52,17 @@ public class Enchanter {
 		EnderTweaker.REMOVALS.add(() -> {
 			Enchantment ench = (Enchantment) output.getInternal();
 			String id = null;
+			IMachineRecipe recipe = null;
 			for (Map.Entry<String, ? extends IMachineRecipe> ent :
 			MachineRecipeRegistry.instance.getRecipesForMachine(MachineRecipeRegistry.ENCHANTER).entrySet()) {
 				if (((EnchanterRecipe) ent.getValue()).getEnchantment() == ench) {
 					id = ent.getKey();
+					recipe = ent.getValue();
 					break;
 				}
 			}
 			if (id != null) {
-				MachineRecipeRegistry.instance.getRecipesForMachine(MachineRecipeRegistry.ENCHANTER).remove(id);
+				MachineRecipeRegistry.instance.removeRecipe(recipe);
 			} else CraftTweakerAPI.logError("No Enchanter recipe found for " + output.getName());
 		});
 	}

--- a/src/main/java/shadows/endertweaker/SoulBinder.java
+++ b/src/main/java/shadows/endertweaker/SoulBinder.java
@@ -39,14 +39,16 @@ public class SoulBinder {
 		EnderTweaker.REMOVALS.add(() -> {
 			ItemStack stack = CraftTweakerMC.getItemStack(output);
 			String id = null;
+			IMachineRecipe recipe = null;
 			for (Map.Entry<String, ? extends IMachineRecipe> ent : MachineRecipeRegistry.instance.getRecipesForMachine(MachineRecipeRegistry.SOULBINDER).entrySet()) {
 				if (OreDictionary.itemMatches(stack, ((ISoulBinderRecipe) ent.getValue()).getOutputStack(), false)) {
 					id = ent.getKey();
+					recipe = ent.getValue();
 					break;
 				}
 			}
 			if (id != null) {
-				MachineRecipeRegistry.instance.getRecipesForMachine(MachineRecipeRegistry.SOULBINDER).remove(id);
+				MachineRecipeRegistry.instance.removeRecipe(recipe);
 			} else CraftTweakerAPI.logError("No Soul Binder recipe found for " + output.getDisplayName());
 		});
 	}


### PR DESCRIPTION
Fixes a crash trying to remove a recipe from the Enchanter or Soulbinder on newer Ender IO versions.

Closes #25 