### PR TITLE
Fix AlloySmelter recipes could not be removed. #27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ build
 # other
 eclipse
 run
+
+# vscode
+.vscode

--- a/Documentation.md
+++ b/Documentation.md
@@ -14,13 +14,13 @@ Parameters:
  - float xp - The xp is granted from this recipe.  May not be negative.
  
 ##### Recipe Removal:
-`removeRecipe(IItemStack output)`  
+`removeRecipe(IItemStack... output)`  
 Parameters:
- - IItemStack output - The output of the recipe to remove.
+ - IItemStack... output - The outputs of the recipes to remove.
 
-`removeByInputs(IItemStack... input)`  
+`removeByInputs(IItemStack[]/IItemStack[][] input)`  
 Parameters:
- - IItemStack... input - The input of the recipe to remove.
+ - IItemStack[]/IItemStack[][] input - The inputs of the recipes to remove.
 ---
 ### Combustion Generator (mods.enderio.CombustionGen)
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
-        maven { url = "http://files.minecraftforge.net/maven" }
+        mavenCentral()
+        maven {url = "http://files.minecraftforge.net/maven"}
     }
     dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
@@ -10,7 +10,7 @@ buildscript {
 apply plugin: 'net.minecraftforge.gradle.forge'
 
 
-version = "1.12.2-1.2.3"
+version = "1.12.2-1.2.4"
 group= "shadows.endertweaker"
 archivesBaseName = "EnderTweaker"
 
@@ -36,18 +36,17 @@ repositories {
 	maven {
 		url 'http://maven.blamejared.com'
 	}
+    maven {
+        url "https://cursemaven.com"
+    }
 }
 
 dependencies {
 	deobfCompile "mezz.jei:jei_1.12.2:+"
-    deobfCompile "mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.4.28-17"
-	deobfCompile("com.enderio:EnderIO:1.12.2-5.3.70"){
-        transitive = false
-    }
-	deobfCompile "com.enderio.core:EnderCore:1.12.2-0.5.76"
+    deobfCompile "curse.maven:the-one-probe-245211:2667280"
+    deobfCompile "curse.maven:enderio-5.3.72-64578:4674244"
+    deobfCompile "curse.maven:endercore-0.5.78-231868:4671384"
 	deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.+"
-	deobfCompile "info.loenwind.autoconfig:AutoConfig:+"
-	deobfCompile "info.loenwind.autosave:AutoSave:1.12.2-+"
 }
 
 processResources

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 apply plugin: 'net.minecraftforge.gradle.forge'
 
 
-version = "1.12.2-1.2.4"
+version = "1.12.2-1.2.5"
 group= "shadows.endertweaker"
 archivesBaseName = "EnderTweaker"
 

--- a/src/main/java/shadows/endertweaker/AlloySmelter.java
+++ b/src/main/java/shadows/endertweaker/AlloySmelter.java
@@ -10,13 +10,14 @@ import crazypants.enderio.base.recipe.IManyToOneRecipe;
 import crazypants.enderio.base.recipe.MachineRecipeInput;
 import crazypants.enderio.base.recipe.RecipeLevel;
 import crazypants.enderio.base.recipe.alloysmelter.AlloyRecipeManager;
+import crazypants.enderio.base.recipe.lookup.TriItemLookup;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
+import shadows.endertweaker.bada774.recipe.AlloySmelterRecipe;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @ZenClass("mods.enderio.AlloySmelter")
@@ -25,8 +26,10 @@ public class AlloySmelter {
 
 	@ZenMethod
 	public static void addRecipe(IItemStack output, IIngredient[] input, @Optional int energyCost, @Optional float xp) {
-		if (hasErrors(output, input)) return;
-		EnderTweaker.ADDITIONS.add(() -> AlloyRecipeManager.getInstance().addRecipe(true, RecipeUtils.toEIOInputsNN(input),
+		if (hasErrors(output, input))
+			return;
+		EnderTweaker.ADDITIONS.add(() -> AlloyRecipeManager.getInstance().addRecipe(true,
+				RecipeUtils.toEIOInputsNN(input),
 				CraftTweakerMC.getItemStack(output), energyCost <= 0 ? 5000 : energyCost, xp, RecipeLevel.IGNORE));
 	}
 
@@ -37,35 +40,62 @@ public class AlloySmelter {
 			return;
 		}
 		EnderTweaker.REMOVALS.add(() -> {
-			ItemStack stack = CraftTweakerMC.getItemStack(output);
-			List<IManyToOneRecipe> removals = new ArrayList<>();
-			for (IManyToOneRecipe r : AlloyRecipeManager.getInstance().getRecipes()) {
-				if (OreDictionary.itemMatches(stack, r.getOutput(), false)) {
-					removals.add(r);
+			List<IManyToOneRecipe> alloyRecipes = AlloySmelterRecipe.getAlloyRecipes();
+			if (alloyRecipes.isEmpty())
+				return;
+			ItemStack targetStack = CraftTweakerMC.getItemStack(output);
+
+			TriItemLookup<IManyToOneRecipe> newLookup = AlloySmelterRecipe.createLookup();
+
+			int removedCount = 0;
+
+			for (IManyToOneRecipe recipe : alloyRecipes) {
+				if (recipe != null && OreDictionary.itemMatches(targetStack, recipe.getOutput(), false)) {
+					removedCount++;
+				} else {
+					AlloySmelterRecipe.addRecipeToLookup(newLookup, recipe);
 				}
 			}
-			if (!removals.isEmpty()) {
-				removals.forEach(AlloyRecipeManager.getInstance().getRecipes()::remove);
-			} else CraftTweakerAPI.logError("No Alloy Smelter recipe found for " + output.getDisplayName());
+			if (removedCount > 0) {
+				AlloySmelterRecipe.setNewLookup(newLookup);
+				CraftTweakerAPI.logInfo("Removed " + removedCount + " recipes for " + output.getDisplayName());
+			} else {
+				CraftTweakerAPI.logError("No Alloy Smelter recipes found for " + output.getDisplayName());
+			}
 		});
 	}
 
 	@ZenMethod
-	public static void removeByInputs(IItemStack... input) {
-		if (input == null || input.length > 3) {
+	public static void removeByInputs(IItemStack... inputs) {
+		if (inputs == null || inputs.length > 3) {
 			CraftTweakerAPI.logError("Cannot remove recipe for null from alloy smelter.");
 			return;
 		}
 		EnderTweaker.REMOVALS.add(() -> {
-			NNList<MachineRecipeInput> inputs = new NNList<>();
-			for (int i = 0; i < input.length; i++) {
-				inputs.add(new MachineRecipeInput(i, CraftTweakerMC.getItemStack(input[i])));
-			}
-			IManyToOneRecipe r = (IManyToOneRecipe)AlloyRecipeManager.getInstance().getRecipeForInputs(RecipeLevel.IGNORE, inputs);
+			List<IManyToOneRecipe> alloyRecipes = AlloySmelterRecipe.getAlloyRecipes();
+			NNList<MachineRecipeInput> targetInputs = new NNList<>();
 
-			if (r != null) {
-				AlloyRecipeManager.getInstance().getRecipes().remove(r);
-			} else CraftTweakerAPI.logError("No Alloy Smelter recipe found for " + RecipeUtils.getDisplayString(input));
+			for (int i = 0; i < inputs.length; i++) {
+				targetInputs.add(new MachineRecipeInput(i, CraftTweakerMC.getItemStack(inputs[i])));
+			}
+
+			TriItemLookup<IManyToOneRecipe> newLookup = AlloySmelterRecipe.createLookup();
+
+			int removedCount = 0;
+
+			for (IManyToOneRecipe recipe : alloyRecipes) {
+				if (recipe != null && recipe.isInputForRecipe(targetInputs)) {
+					removedCount++;
+				} else {
+					AlloySmelterRecipe.addRecipeToLookup(newLookup, recipe);
+				}
+			}
+			if (removedCount > 0) {
+				AlloySmelterRecipe.setNewLookup(newLookup);
+				CraftTweakerAPI.logInfo("Removed " + removedCount + " recipes matching given inputs.");
+			} else {
+				CraftTweakerAPI.logError("No Alloy Smelter recipes found matching given inputs.");
+			}
 		});
 	}
 
@@ -75,7 +105,8 @@ public class AlloySmelter {
 			return true;
 		}
 		if (input.length > 3) {
-			CraftTweakerAPI.logError("Invalid Alloy Smelter input, must be between 1 and 3 inputs. Provided: " + RecipeUtils.getDisplayString(input));
+			CraftTweakerAPI.logError("Invalid Alloy Smelter input, must be between 1 and 3 inputs. Provided: "
+					+ RecipeUtils.getDisplayString(input));
 			return true;
 		}
 		return false;

--- a/src/main/java/shadows/endertweaker/AlloySmelter.java
+++ b/src/main/java/shadows/endertweaker/AlloySmelter.java
@@ -13,11 +13,13 @@ import crazypants.enderio.base.recipe.alloysmelter.AlloyRecipeManager;
 import crazypants.enderio.base.recipe.lookup.TriItemLookup;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
+import shadows.endertweaker.bada774.Logging;
 import shadows.endertweaker.bada774.recipe.AlloySmelterRecipe;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @ZenClass("mods.enderio.AlloySmelter")
@@ -34,68 +36,170 @@ public class AlloySmelter {
 	}
 
 	@ZenMethod
-	public static void removeRecipe(IItemStack output) {
-		if (output == null) {
-			CraftTweakerAPI.logError("Cannot remove recipe for null from alloy smelter.");
+	public static void removeRecipe(IItemStack... outputs) {
+		if (outputs == null || outputs.length == 0) {
+			CraftTweakerAPI.logError("Cannot remove recipes for null from Alloy Smelter.");
 			return;
 		}
 		EnderTweaker.REMOVALS.add(() -> {
 			List<IManyToOneRecipe> alloyRecipes = AlloySmelterRecipe.getAlloyRecipes();
 			if (alloyRecipes.isEmpty())
 				return;
-			ItemStack targetStack = CraftTweakerMC.getItemStack(output);
+
+			List<ItemStack> targetOutputs = new ArrayList<>();
+			List<String> targetNames = new ArrayList<>();
+
+			for (IItemStack output : outputs) {
+				if (output != null && !output.isEmpty()) {
+					targetOutputs.add(CraftTweakerMC.getItemStack(output));
+					targetNames.add(output.getDisplayName());
+				} else {
+					CraftTweakerAPI.logError("Invalid output null in Alloy Smelter recipe removal: " + output);
+				}
+			}
+
+			if (targetOutputs.isEmpty())
+				return;
+
+			boolean[] foundMatch = new boolean[targetOutputs.size()];
 
 			TriItemLookup<IManyToOneRecipe> newLookup = AlloySmelterRecipe.createLookup();
 
 			int removedCount = 0;
-
 			for (IManyToOneRecipe recipe : alloyRecipes) {
-				if (recipe != null && OreDictionary.itemMatches(targetStack, recipe.getOutput(), false)) {
+				if (recipe == null)
+					continue;
+
+				boolean shouldRemove = false;
+				for (int i = 0; i < targetOutputs.size(); i++) {
+					if (OreDictionary.itemMatches(targetOutputs.get(i), recipe.getOutput(), false)) {
+						shouldRemove = true;
+						foundMatch[i] = true;
+						break;
+					}
+				}
+				if (shouldRemove) {
 					removedCount++;
 				} else {
 					AlloySmelterRecipe.addRecipeToLookup(newLookup, recipe);
 				}
 			}
+
 			if (removedCount > 0) {
 				AlloySmelterRecipe.setNewLookup(newLookup);
-				CraftTweakerAPI.logInfo("Removed " + removedCount + " recipes for " + output.getDisplayName());
-			} else {
-				CraftTweakerAPI.logError("No Alloy Smelter recipes found for " + output.getDisplayName());
 			}
+
+			List<String> successRemovedList = new ArrayList<>();
+			List<String> missingList = new ArrayList<>();
+
+			for (int i = 0; i < foundMatch.length; i++) {
+				if (foundMatch[i]) {
+					successRemovedList.add(targetNames.get(i));
+				} else {
+					missingList.add(targetNames.get(i));
+				}
+			}
+			Logging.logRemovalResult("Alloy Smelter", removedCount, "removeRecipe", successRemovedList, missingList);
 		});
 	}
 
 	@ZenMethod
-	public static void removeByInputs(IItemStack... inputs) {
-		if (inputs == null || inputs.length > 3) {
-			CraftTweakerAPI.logError("Cannot remove recipe for null from alloy smelter.");
+	public static void removeByInputs(IItemStack[] inputs) {
+		executeRemoveByInputs(new IItemStack[][] { inputs }, "removeByInputs");
+	}
+
+	@ZenMethod
+	public static void removeMultipleByInputs(IItemStack[][] inputs) {
+		executeRemoveByInputs(inputs, "removeMultipleByInputs");
+	}
+
+	public static void executeRemoveByInputs(IItemStack[][] inputs, String callerName) {
+		if (inputs == null || inputs.length == 0) {
+			CraftTweakerAPI.logError("Cannot remove recipes by inputs: inputs are null.");
 			return;
 		}
 		EnderTweaker.REMOVALS.add(() -> {
 			List<IManyToOneRecipe> alloyRecipes = AlloySmelterRecipe.getAlloyRecipes();
-			NNList<MachineRecipeInput> targetInputs = new NNList<>();
+			if (alloyRecipes.isEmpty())
+				return;
 
-			for (int i = 0; i < inputs.length; i++) {
-				targetInputs.add(new MachineRecipeInput(i, CraftTweakerMC.getItemStack(inputs[i])));
+			List<NNList<MachineRecipeInput>> targetsList = new ArrayList<>();
+			List<IItemStack[]> validInputs = new ArrayList<>();
+
+			for (IItemStack[] filterInput : inputs) {
+				if (filterInput == null || filterInput.length == 0
+						|| filterInput.length > 3) {
+					CraftTweakerAPI.logError(
+							"Invalid Alloy Smelter recipe inputs: " + RecipeUtils.getDisplayString(filterInput));
+					continue;
+				}
+
+				NNList<MachineRecipeInput> targetInputs = new NNList<>();
+
+				for (int i = 0; i < filterInput.length; i++) {
+					if (filterInput[i] != null) {
+						targetInputs.add(new MachineRecipeInput(i, CraftTweakerMC.getItemStack(filterInput[i])));
+					}
+				}
+				targetsList.add(targetInputs);
+				validInputs.add(filterInput);
 			}
+
+			if (targetsList.isEmpty())
+				return;
+
+			boolean[] foundMatch = new boolean[targetsList.size()];
 
 			TriItemLookup<IManyToOneRecipe> newLookup = AlloySmelterRecipe.createLookup();
 
 			int removedCount = 0;
-
 			for (IManyToOneRecipe recipe : alloyRecipes) {
-				if (recipe != null && recipe.isInputForRecipe(targetInputs)) {
+				if (recipe == null)
+					continue;
+
+				boolean shouldRemove = false;
+				for (int i = 0; i < targetsList.size(); i++) {
+					if (recipe.isInputForRecipe(targetsList.get(i))) {
+						shouldRemove = true;
+						foundMatch[i] = true;
+						break;
+					}
+				}
+
+				if (shouldRemove) {
 					removedCount++;
 				} else {
 					AlloySmelterRecipe.addRecipeToLookup(newLookup, recipe);
 				}
 			}
+
 			if (removedCount > 0) {
 				AlloySmelterRecipe.setNewLookup(newLookup);
-				CraftTweakerAPI.logInfo("Removed " + removedCount + " recipes matching given inputs.");
-			} else {
-				CraftTweakerAPI.logError("No Alloy Smelter recipes found matching given inputs.");
 			}
+
+			List<String> successLog = new ArrayList<>();
+			List<String> missingLog = new ArrayList<>();
+
+			for (int i = 0; i < foundMatch.length; i++) {
+				StringBuilder sbName = new StringBuilder("[");
+				boolean firstItem = true;
+				for (IItemStack item : validInputs.get(i)) {
+					if (item != null) {
+						if (!firstItem)
+							sbName.append(", ");
+						sbName.append(item.getDisplayName());
+						firstItem = false;
+					}
+				}
+				sbName.append("]");
+				if (foundMatch[i]) {
+					successLog.add(sbName.toString());
+				} else {
+					missingLog.add(sbName.toString());
+				}
+			}
+
+			Logging.logRemovalResult("Alloy Smelter", removedCount, callerName, successLog, missingLog);
 		});
 	}
 

--- a/src/main/java/shadows/endertweaker/AlloySmelter.java
+++ b/src/main/java/shadows/endertweaker/AlloySmelter.java
@@ -130,7 +130,8 @@ public class AlloySmelter {
 				if (filterInput == null || filterInput.length == 0
 						|| filterInput.length > 3) {
 					CraftTweakerAPI.logError(
-							"Invalid Alloy Smelter recipe inputs: " + RecipeUtils.getDisplayString(filterInput));
+							"Invalid Alloy Smelter recipe inputs: " + ((filterInput == null) ? "null"
+									: RecipeUtils.getDisplayString(filterInput)));
 					continue;
 				}
 

--- a/src/main/java/shadows/endertweaker/EnderTweaker.java
+++ b/src/main/java/shadows/endertweaker/EnderTweaker.java
@@ -8,12 +8,12 @@ import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import java.util.ArrayList;
 import java.util.List;
 
-@Mod(modid = EnderTweaker.MODID, name = EnderTweaker.MODNAME, version = EnderTweaker.VERSION, dependencies = "required:enderio@[5.2.60,);required-after:crafttweaker;before:jei")
+@Mod(modid = EnderTweaker.MODID, name = EnderTweaker.MODNAME, version = EnderTweaker.VERSION, dependencies = "required:enderio@[5.3.67,);required-after:crafttweaker;before:jei")
 public class EnderTweaker {
 
 	public static final String MODID = "endertweaker";
 	public static final String MODNAME = "EnderTweaker";
-	public static final String VERSION = "1.2.3";
+	public static final String VERSION = "1.2.4";
 	public static final List<Runnable> ADDITIONS = new ArrayList<>();
 	public static final List<Runnable> REMOVALS = new ArrayList<>();
 

--- a/src/main/java/shadows/endertweaker/EnderTweaker.java
+++ b/src/main/java/shadows/endertweaker/EnderTweaker.java
@@ -13,7 +13,7 @@ public class EnderTweaker {
 
 	public static final String MODID = "endertweaker";
 	public static final String MODNAME = "EnderTweaker";
-	public static final String VERSION = "1.2.4";
+	public static final String VERSION = "1.2.5";
 	public static final List<Runnable> ADDITIONS = new ArrayList<>();
 	public static final List<Runnable> REMOVALS = new ArrayList<>();
 

--- a/src/main/java/shadows/endertweaker/bada774/Logging.java
+++ b/src/main/java/shadows/endertweaker/bada774/Logging.java
@@ -1,0 +1,22 @@
+package shadows.endertweaker.bada774;
+
+import java.util.List;
+
+import crafttweaker.CraftTweakerAPI;
+
+public class Logging {
+
+    public static void logRemovalResult(String machineName, int count, String type, List<String> successLog,
+            List<String> missingLog) {
+        if (!successLog.isEmpty()) {
+            String joinedSuccess = String.join(", ", successLog);
+            CraftTweakerAPI
+                    .logInfo("Removed " + count + " " + machineName + " recipes (" + type + ") for: " + joinedSuccess);
+        }
+
+        if (!missingLog.isEmpty()) {
+            String joinedMissing = String.join(", ", missingLog);
+            CraftTweakerAPI.logWarning("No " + machineName + " recipes (" + type + ") found for: " + joinedMissing);
+        }
+    }
+}

--- a/src/main/java/shadows/endertweaker/bada774/recipe/AlloySmelterRecipe.java
+++ b/src/main/java/shadows/endertweaker/bada774/recipe/AlloySmelterRecipe.java
@@ -1,0 +1,62 @@
+package shadows.endertweaker.bada774.recipe;
+
+import crazypants.enderio.base.recipe.alloysmelter.AlloyRecipeManager;
+import crazypants.enderio.base.recipe.IManyToOneRecipe;
+import crazypants.enderio.base.recipe.lookup.TriItemLookup;
+import crafttweaker.CraftTweakerAPI;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+
+public class AlloySmelterRecipe {
+
+    private static final Field lookupField;
+    private static final Method addRecipeMethod;
+
+    static {
+        try {
+            lookupField = AlloyRecipeManager.class.getDeclaredField("lookup");
+            lookupField.setAccessible(true);
+
+            addRecipeMethod = AlloyRecipeManager.class.getDeclaredMethod("addRecipeToLookup",
+                    TriItemLookup.class, IManyToOneRecipe.class);
+            addRecipeMethod.setAccessible(true);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to initialize AlloySmelter reflection helpers: ", e);
+        }
+
+    }
+
+    public static List<IManyToOneRecipe> getAlloyRecipes() {
+        List<IManyToOneRecipe> alloySmelterRecipes = AlloyRecipeManager.getInstance().getRecipes();
+        if (!alloySmelterRecipes.isEmpty())
+            return alloySmelterRecipes;
+        CraftTweakerAPI.logError("AlloyRecipeManager returned null recipe list!");
+        return Collections.emptyList();
+    }
+
+    public static TriItemLookup<IManyToOneRecipe> createLookup() {
+        return new TriItemLookup<>();
+    }
+
+    public static void addRecipeToLookup(TriItemLookup<IManyToOneRecipe> lookup, IManyToOneRecipe recipe) {
+        try {
+            addRecipeMethod.invoke(null, lookup, recipe);
+        } catch (Exception e) {
+            CraftTweakerAPI.logError("Error adding recipe to new lookup via reflection");
+            e.printStackTrace();
+        }
+    }
+
+    public static void setNewLookup(TriItemLookup<IManyToOneRecipe> newLookup) {
+        try {
+            lookupField.set(AlloyRecipeManager.getInstance(), newLookup);
+
+        } catch (Exception e) {
+            CraftTweakerAPI.logError("Failed to set Alloy Smelter recipe lookup: ", e);
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/shadows/endertweaker/bada774/recipe/AlloySmelterRecipe.java
+++ b/src/main/java/shadows/endertweaker/bada774/recipe/AlloySmelterRecipe.java
@@ -45,7 +45,7 @@ public class AlloySmelterRecipe {
         try {
             addRecipeMethod.invoke(null, lookup, recipe);
         } catch (Exception e) {
-            CraftTweakerAPI.logError("Error adding recipe to new lookup via reflection");
+            CraftTweakerAPI.logError("Error adding recipe to new lookup via reflection:\n", e);
             e.printStackTrace();
         }
     }
@@ -55,7 +55,7 @@ public class AlloySmelterRecipe {
             lookupField.set(AlloyRecipeManager.getInstance(), newLookup);
 
         } catch (Exception e) {
-            CraftTweakerAPI.logError("Failed to set Alloy Smelter recipe lookup: ", e);
+            CraftTweakerAPI.logError("Failed to set Alloy Smelter recipe lookup:\n", e);
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
Fix Alloy Smelter's recipes could not be removed due to major rework of the `AlloyRecipeManager` class in EnderIO v5.3.67. 
Now it rebuilds EnderIO's private recipes list using reflection mechanism.
Closes: #27

Also add support for multiple removal, mainly for optimization purposes (to avoid multiple re-creation of recipe lists).

Tested with: 
- MC: 1.12.2
- EnderCore: v.0.5.78 (07.29.2023)
- EnderIO:
   - v.5.3.72 (07.31.2023)
   - v.5.3.70 (05.29.2021)
   - v.5.3.68 (05.26.2021)
   - v.5.3.67 (05.24.2021)

